### PR TITLE
Fixing urls by replacing "_" to match the "-" in the repo.

### DIFF
--- a/packages/artdaq-core-demo/package.py
+++ b/packages/artdaq-core-demo/package.py
@@ -22,8 +22,8 @@ class ArtdaqCoreDemo(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_core_demo/archive/refs/tags/v1_10_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_core_demo.git"
+    url = "https://github.com/art-daq/artdaq-core-demo/archive/refs/tags/v1_10_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-core-demo.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_12_00", commit="b751d08973539b787288c87f40dbac454a745031")
@@ -36,7 +36,7 @@ class ArtdaqCoreDemo(CMakePackage):
     version("v1_10_02", commit="aba71a8cae83b0cb32eecebebada1c1efcad0b4f")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_core_demo/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-core-demo/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-core/package.py
+++ b/packages/artdaq-core/package.py
@@ -23,8 +23,8 @@ class ArtdaqCore(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_core/archive/refs/tags/v3_09_04.tar.gz"
-    git = "https://github.com/art-daq/artdaq_core.git"
+    url = "https://github.com/art-daq/artdaq-core/archive/refs/tags/v3_09_04.tar.gz"
+    git = "https://github.com/art-daq/artdaq-core.git"
 
     version("v3_13_00", commit="75fb6a28438ff4a9a74dc9128c5bc05b11ae97f4")
     version("v3_12_00", commit="34d404d42b6d9bf3ae33b20aebd1fa6fc404a409")
@@ -74,7 +74,7 @@ class ArtdaqCore(CMakePackage):
     depends_on("doxygen", when="+doc")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_core/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-core/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     def cmake_args(self):

--- a/packages/artdaq-daqinterface/package.py
+++ b/packages/artdaq-daqinterface/package.py
@@ -18,11 +18,11 @@ class ArtdaqDaqinterface(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_daqinterface/archive/refs/tags/v3_12_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_daqinterface.git"
+    url = "https://github.com/art-daq/artdaq-daqinterface/archive/refs/tags/v3_12_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-daqinterface.git"
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_daqinterface/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-daqinterface/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     version("develop", branch="develop", get_full_repo=True)

--- a/packages/artdaq-database/package.py
+++ b/packages/artdaq-database/package.py
@@ -18,8 +18,8 @@ class ArtdaqDatabase(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_database/archive/refs/tags/v1_07_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_database.git"
+    url = "https://github.com/art-daq/artdaq-database/archive/refs/tags/v1_07_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-database.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_10_02", commit="2e92a4357c9b4a7dbe2259a8d6dcf9b1dc39d582")
@@ -31,7 +31,7 @@ class ArtdaqDatabase(CMakePackage):
     version("v1_07_02", commit="a3d27b761786aeb7fdff6dc1baeaca9b8bedbcce")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_database/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-database/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-demo/package.py
+++ b/packages/artdaq-demo/package.py
@@ -23,8 +23,8 @@ class ArtdaqDemo(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_demo/archive/refs/tags/v3_12_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_demo.git"
+    url = "https://github.com/art-daq/artdaq-demo/archive/refs/tags/v3_12_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-demo.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v3_16_00", commit="ece227114da3fc374c9c04446e01182b8b49bb1c")
@@ -40,7 +40,7 @@ class ArtdaqDemo(CMakePackage):
     version("v3_12_02", commit="082d1df470d7f826801c10c5f3b1e844e110c1a4")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_demo/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-demo/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-epics-plugin/package.py
+++ b/packages/artdaq-epics-plugin/package.py
@@ -23,8 +23,8 @@ class ArtdaqEpicsPlugin(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_epics_plugin/archive/refs/tags/v1_05_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_epics_plugin.git"
+    url = "https://github.com/art-daq/artdaq-epics-plugin/archive/refs/tags/v1_05_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-epics-plugin.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_07_00", commit="21dd76ab9b73ad3293f33ecce0e73d227472c853")
@@ -38,7 +38,7 @@ class ArtdaqEpicsPlugin(CMakePackage):
     version("v1_05_02", commit="0cfb5bbb8f079dff64c7bce1f11524b0e0c97a64")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_epics_plugin/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-epics-plugin/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-mfextensions/package.py
+++ b/packages/artdaq-mfextensions/package.py
@@ -23,8 +23,8 @@ class ArtdaqMfextensions(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_mfextensions/archive/refs/tags/v1_08_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_mfextensions.git"
+    url = "https://github.com/art-daq/artdaq-mfextensions/archive/refs/tags/v1_08_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-mfextensions.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_10_00", commit="6be6276c9c7798ab032935ca8053f910dd65b116")
@@ -38,7 +38,7 @@ class ArtdaqMfextensions(CMakePackage):
     version("v1_08_02", commit="e8bee6a61cdbfadea9c96c95865dc138c2bdf815")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_mfextensions/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-mfextensions/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-pcp-mmv-plugin/package.py
+++ b/packages/artdaq-pcp-mmv-plugin/package.py
@@ -23,8 +23,8 @@ class ArtdaqPcpMmvPlugin(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_pcp_mmv_plugin/archive/refs/tags/v1_03_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_pcp_mmv_plugin.git"
+    url = "https://github.com/art-daq/artdaq-pcp-mmv-plugin/archive/refs/tags/v1_03_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-pcp-mmv-plugin.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_04_00", commit="c1dc4e08a717fac9e75f3c765639463734c297b0")
@@ -34,7 +34,7 @@ class ArtdaqPcpMmvPlugin(CMakePackage):
     version("v1_03_02", commit="a09b0f3e137d300f8507f6e140301ec8a2a2748a")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_pcp_mmv_plugin/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-pcp-mmv-plugin/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/artdaq-utilities/package.py
+++ b/packages/artdaq-utilities/package.py
@@ -23,8 +23,8 @@ class ArtdaqUtilities(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/artdaq_utilities/archive/refs/tags/v1_08_02.tar.gz"
-    git = "https://github.com/art-daq/artdaq_utilities.git"
+    url = "https://github.com/art-daq/artdaq-utilities/archive/refs/tags/v1_08_02.tar.gz"
+    git = "https://github.com/art-daq/artdaq-utilities.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v1_11_00", commit="62e841ecc45baeccfaf49ceafc3151f7f75c4b97")
@@ -37,7 +37,7 @@ class ArtdaqUtilities(CMakePackage):
     version("v1_08_02", commit="c3382790c56b109adeae0eaf30a5a9f422d6ccbf")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/artdaq_utilities/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/artdaq-utilities/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/otsdaq-components/package.py
+++ b/packages/otsdaq-components/package.py
@@ -18,8 +18,8 @@ class OtsdaqComponents(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/otsdaq_components/archive/refs/tags/v2_06_08.tar.gz"
-    git = "https://github.com/art-daq/otsdaq_components.git"
+    url = "https://github.com/art-daq/otsdaq-components/archive/refs/tags/v2_06_08.tar.gz"
+    git = "https://github.com/art-daq/otsdaq-components.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v2_10_00", commit="1938539dbdc9c6af78d3557093bcaffcf7e8f666")
@@ -35,7 +35,7 @@ class OtsdaqComponents(CMakePackage):
     version("v2_06_08", commit="75a30ad1bfb44b0817e791a9cea993df8cc33c7c")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/otsdaq_components/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/otsdaqcomponents/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/otsdaq-demo/package.py
+++ b/packages/otsdaq-demo/package.py
@@ -24,8 +24,8 @@ class OtsdaqDemo(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/otsdaq_demo/archive/refs/tags/v2_06_08.tar.gz"
-    git = "https://github.com/art-daq/otsdaq_demo.git"
+    url = "https://github.com/art-daq/otsdaq-demo/archive/refs/tags/v2_06_08.tar.gz"
+    git = "https://github.com/art-daq/otsdaq-demo.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v2_10_00", commit="d0c90f7a2b1114bfea0b64eb20cbdb9b40c4651e")
@@ -41,7 +41,7 @@ class OtsdaqDemo(CMakePackage):
     version("v2_06_08", commit="4c2aaa53e27ca6ef0a98bfaed0e66e4a9e2e6b34")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/otsdaq_demo/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/otsdaq-demo/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/otsdaq-epics/package.py
+++ b/packages/otsdaq-epics/package.py
@@ -18,8 +18,8 @@ class OtsdaqEpics(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/otsdaq_epics/archive/refs/tags/v2_06_08.tar.gz"
-    git = "https://github.com/art-daq/otsdaq_epics.git"
+    url = "https://github.com/art-daq/otsdaq-epics/archive/refs/tags/v2_06_08.tar.gz"
+    git = "https://github.com/art-daq/otsdaq-epics.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v2_10_00", commit="245f56ddb5345c8199c5bb8c765ee1b0ba727620")
@@ -35,7 +35,7 @@ class OtsdaqEpics(CMakePackage):
     version("v2_06_08", commit="32bdbcd6ec727eda64766aa2d70ae2b7871a98eb")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/otsdaq_epics/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/otsdaq-epics/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/otsdaq-prepmodernization/package.py
+++ b/packages/otsdaq-prepmodernization/package.py
@@ -25,8 +25,8 @@ class OtsdaqPrepmodernization(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/otsdaq_prepmodernization/archive/refs/tags/v2_06_08.tar.gz"
-    git = "https://github.com/art-daq/otsdaq_prepmodernization.git"
+    url = "https://github.com/art-daq/otsdaq-prepmodernization/archive/refs/tags/v2_06_08.tar.gz"
+    git = "https://github.com/art-daq/otsdaq-prepmodernization.git"
 
     version("develop", branch="develop", get_full_repo=True)
     version("v2_10_00", commit="40f6197b16c5e1f040a9638c572da383771a929a")
@@ -42,7 +42,7 @@ class OtsdaqPrepmodernization(CMakePackage):
     version("v2_06_08", commit="70d400ec9d03cea9ec60429954b845d667c88622")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/otsdaq_prepmodernization/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/otsdaq-prepmodernization/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(

--- a/packages/otsdaq-utilities/package.py
+++ b/packages/otsdaq-utilities/package.py
@@ -18,8 +18,8 @@ class OtsdaqUtilities(CMakePackage):
     format."""
 
     homepage = "https://cdcvs.fnal.gov/redmine/projects/artdaq/wiki"
-    url = "https://github.com/art-daq/otsdaq_utilities/archive/refs/tags/v2_06_08.tar.gz"
-    git = "https://github.com/art-daq/otsdaq_utilities.git"
+    url = "https://github.com/art-daq/otsdaq-utilities/archive/refs/tags/v2_06_08.tar.gz"
+    git = "https://github.com/art-daq/otsdaq-utilities.git"
 
     version("develop", branch="develop", get_full_repo=True, submodules=True)
     version("v2_10_00", commit="15d657c38c538facc92c4d40d0ecf25c8b580cb7")
@@ -35,7 +35,7 @@ class OtsdaqUtilities(CMakePackage):
     version("v2_06_08", commit="e02546704301d7506bec0fe842ac9789e57d9f43")
 
     def url_for_version(self, version):
-        url = "https://github.com/art-daq/otsdaq_utilities/archive/refs/tags/{0}.tar.gz"
+        url = "https://github.com/art-daq/otsdaq-utilities/archive/refs/tags/{0}.tar.gz"
         return url.format(version)
 
     variant(


### PR DESCRIPTION
In the "package.py" the urls for all of the repos were of the format "artdaq_core". If you go to the URLs, they redirect to "artdaq-core" instead. This can be seen when you try to use ```wget``` on any of the archives: 
<img width="908" alt="Screenshot 2025-02-24 at 3 31 51 PM" src="https://github.com/user-attachments/assets/61cc61de-f702-4265-a57c-a0996cdcb4a0" />

This somehow caused issues when we were using spack to install. We were previously using an old commit of this repository, but when we moved to this current commit we encountered these issues: 
<img width="770" alt="Screenshot 2025-02-24 at 3 42 47 PM" src="https://github.com/user-attachments/assets/6139eadf-e0ee-442c-aeb7-b4f1c98f5ef8" />
<img width="760" alt="Screenshot 2025-02-24 at 3 43 58 PM" src="https://github.com/user-attachments/assets/89f3d31e-2395-47b9-b17c-82ea77fd426e" />

I was wondering if this fix might help with the warnings and this error we've seen occasionally.