### PR TITLE
rename llnl -> spack.llnl for v1

### DIFF
--- a/spack_repo/artdaq_spack/packages/trace/package.py
+++ b/spack_repo/artdaq_spack/packages/trace/package.py
@@ -7,7 +7,7 @@
 import os
 import sys
 from spack.util.environment import EnvironmentModifications
-from llnl.util.filesystem import join_path
+from spack.llnl.util.filesystem import join_path
 
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *


### PR DESCRIPTION
changes `llnl` import to `spack.llnl` to silence a deprecation warning, as the import path was updated in spack 1.0.