### PR TITLE
changes for full dune build on spack v1.0.0-fermi

### DIFF
--- a/spack_repo/artdaq_spack/packages/art_suite/package.py
+++ b/spack_repo/artdaq_spack/packages/art_suite/package.py
@@ -15,6 +15,7 @@ class ArtSuite(BundlePackage):
 
     homepage="https://github.com/art-framework-suite/"
 
+    variant("bundle", default=True, description="specify particular versions by version")
     version("s132")
     version("s131")
     version("s130")
@@ -32,12 +33,42 @@ class ArtSuite(BundlePackage):
 
     variant("root", default=True, description="Also bring in the ROOT IO packages")
 
-    with when("@s132"):
+    with when("~bundle"):
+        depends_on("cmake")
+
+        depends_on("art ")
+        depends_on("art-root-io ", when="+root")
+        depends_on("boost+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+system+test+thread+timer+wave") # Sum of all needed libraries...
+        depends_on("canvas ")
+        depends_on("canvas-root-io ", when="+root")
+        depends_on("catch2")
+        depends_on("cetlib ")
+        depends_on("cetlib-except ")
+        depends_on("cetmodules")
+        depends_on("clhep")
+        depends_on("fftw")
+        depends_on("fhicl-cpp ")
+        depends_on("gsl")
+        depends_on("hep-concurrency ")
+        depends_on("libxml2")
+        depends_on("messagefacility ")
+        depends_on("py-numpy")
+        depends_on("openblas")
+        depends_on("postgresql") # 15.3 not published to Spack
+        depends_on("py-pybind11")
+        depends_on("pythia6")
+        depends_on("python")
+        depends_on("range-v3")
+        depends_on("root +http+mlp+root7+spectrum+tmva+tmva-sofie ", when="+root")
+        depends_on("sqlite")
+        depends_on("tbb")
+        depends_on("xrootd")
+    with when("@s132 +bundle"):
         depends_on("cmake@3.27.9:")
 
         depends_on("art@3.15.00 cxxstd=20")
         depends_on("art-root-io@1.14.00 cxxstd=20", when="+root")
-        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
         depends_on("canvas@3.17.00 cxxstd=20")
         depends_on("canvas-root-io@1.14.00 cxxstd=20", when="+root")
         depends_on("catch2@3.3.2")
@@ -62,12 +93,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.9.0")
         depends_on("xrootd@5.5.5")
-    with when("@s131"):
+    with when("@s131 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.14.04 cxxstd=20")
         depends_on("art-root-io@1.13.06 cxxstd=20", when="+root")
-        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
         depends_on("canvas@3.16.04 cxxstd=20")
         depends_on("canvas-root-io@1.13.06 cxxstd=20", when="+root")
         depends_on("catch2@3.3.2")
@@ -92,12 +123,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.9.0")
         depends_on("xrootd@5.5.5")
-    with when("@s130"):
+    with when("@s130 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.14.04 cxxstd=20")
         depends_on("art-root-io@1.13.05 cxxstd=20", when="+root")
-        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
         depends_on("canvas@3.16.04 cxxstd=20")
         depends_on("canvas-root-io@1.13.05 cxxstd=20", when="+root")
         depends_on("catch2@3.3.2")
@@ -122,12 +153,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.9.0")
         depends_on("xrootd@5.5.5")
-    with when("@s128"):
+    with when("@s128 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.14.03 cxxstd=20")
         depends_on("art-root-io@1.13.03 cxxstd=20", when="+root")
-        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
         depends_on("canvas@3.16.03 cxxstd=20")
         depends_on("canvas-root-io@1.13.03 cxxstd=20", when="+root")
         depends_on("catch2@3.3.2")
@@ -152,12 +183,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.9.0")
         depends_on("xrootd@5.5.5")
-    with when("@s126"):
+    with when("@s126 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.14.01 cxxstd=20")
         depends_on("art-root-io@1.13.01 cxxstd=20", when="+root")
-        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
+        depends_on("boost@1.82.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=20") # Sum of all needed libraries...
         depends_on("canvas@3.16.01 cxxstd=20")
         depends_on("canvas-root-io@1.13.01 cxxstd=20", when="+root")
         depends_on("catch2@3.3.2")
@@ -182,12 +213,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.9.0")
         depends_on("xrootd@5.5.5")
-    with when("@s124"):
+    with when("@s124 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.13.02 cxxstd=17")
         depends_on("art-root-io@1.12.03 cxxstd=17", when="+root")
-        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.15.01 cxxstd=17")
         depends_on("canvas-root-io@1.12.02 cxxstd=17", when="+root")
         depends_on("catch2@3.3.1")
@@ -212,12 +243,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.8.0 cxxstd=17")
         depends_on("xrootd@5.5.3 cxxstd=17")
-    with when("@s123"):
+    with when("@s123 +bundle"):
         depends_on("cmake@3.27.9")
 
         depends_on("art@3.13.01 cxxstd=17")
         depends_on("art-root-io@1.12.03 cxxstd=17", when="+root")
-        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.15.01 cxxstd=17")
         depends_on("canvas-root-io@1.12.02 cxxstd=17", when="+root")
         depends_on("catch2@3.3.1")
@@ -242,12 +273,12 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.8.0 cxxstd=17")
         depends_on("xrootd@5.5.3 cxxstd=17")
-    with when("@s122"):
+    with when("@s122 +bundle"):
         depends_on("cmake@3.26.2")
 
         depends_on("art@3.13.01 cxxstd=17")
         depends_on("art-root-io@1.12.02 cxxstd=17", when="+root")
-        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.81.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.15.01 cxxstd=17")
         depends_on("canvas-root-io@1.12.01 cxxstd=17", when="+root")
         depends_on("catch2@3.3.1")
@@ -272,10 +303,10 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.40.1")
         depends_on("tbb@2021.8.0 cxxstd=17")
         depends_on("xrootd@5.5.1 cxxstd=17")
-    with when("@s120b"):
+    with when("@s120b +bundle"):
         depends_on("art@3.12.01 cxxstd=17")
         depends_on("art-root-io@1.11.04 cxxstd=17", when="+root")
-        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.14.01 cxxstd=17")
         depends_on("canvas-root-io@1.11.03 cxxstd=17", when="+root")
         depends_on("catch2@3.3.1") # 2.13.9 in manifest, but art package has conflicts at 2.12
@@ -300,10 +331,10 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.39.2")
         depends_on("tbb@2021.7.0 cxxstd=17")
         depends_on("xrootd@5.4.3 cxxstd=17")
-    with when("@s120a"):
+    with when("@s120a +bundle"):
         depends_on("art@3.12.00 cxxstd=17")
         depends_on("art-root-io@1.11.03 cxxstd=17", when="+root")
-        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.14.00 cxxstd=17")
         depends_on("canvas-root-io@1.11.02 cxxstd=17", when="+root")
         depends_on("catch2@2.13.9")
@@ -328,10 +359,10 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.39.2")
         depends_on("tbb@2021.7.0 cxxstd=17")
         depends_on("xrootd@5.4.3 cxxstd=17")
-#    with when("@s120"):
+#    with when("@s120 +bundle"):
 #        depends_on("art@3.12.00 cxxstd=17")
 #        depends_on("art-root-io@1.11.02 cxxstd=17", when="+root")
-#        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+#        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
 #        depends_on("canvas@3.14.00 cxxstd=17")
 #        depends_on("canvas-root-io@1.11.01 cxxstd=17", when="+root")
 #        depends_on("catch2@2.13.9")
@@ -356,10 +387,10 @@ class ArtSuite(BundlePackage):
 #        depends_on("sqlite@3.39.2")
 #        depends_on("tbb@2021.7.0 cxxstd=17")
 #        depends_on("xrootd@5.4.3 cxxstd=17")
-    with when("@s118"):
+    with when("@s118 +bundle"):
         depends_on("art@3.12.00 cxxstd=17")
         depends_on("art-root-io@1.11.00 cxxstd=17", when="+root")
-        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.80.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.14.00 cxxstd=17")
         depends_on("canvas-root-io@1.11.00 cxxstd=17", when="+root")
         depends_on("catch2@2.13.8 ")
@@ -384,10 +415,10 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.39.2")
         depends_on("tbb@2021.7.0 cxxstd=17")
         depends_on("xrootd@5.4.3 cxxstd=17")
-    with when("@s117"):
+    with when("@s117 +bundle"):
         depends_on("art@3.09.04 cxxstd=17")
         depends_on("art-root-io@1.08.05 cxxstd=17", when="+root")
-        depends_on("boost@1.75.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.75.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.12.05 cxxstd=17")
         depends_on("canvas-root-io@1.09.05 cxxstd=17", when="+root")
         depends_on("catch2@2.13.4")
@@ -414,10 +445,10 @@ class ArtSuite(BundlePackage):
         depends_on("sqlite@3.34.0")
         depends_on("tbb@2021.1.1 cxxstd=17")
         depends_on("xrootd@5.1.0 cxxstd=17")
-    with when("@s112"):
+    with when("@s112 +bundle"):
         depends_on("art@3.09.03 cxxstd=17")
         depends_on("art-root-io@1.08.03 cxxstd=17", when="+root")
-        depends_on("boost@1.75.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
+        depends_on("boost@1.75.0+atomic+chrono+date_time+exception+filesystem+graph+iostreams+json+locale+log+math+multithreaded+program_options+random+regex+serialization+shared+signals2+system+test+thread+timer+wave cxxstd=17") # Sum of all needed libraries...
         depends_on("canvas@3.12.04 cxxstd=17")
         depends_on("canvas-root-io@1.09.04 cxxstd=17", when="+root")
         depends_on("catch2@2.13.4")

--- a/spack_repo/artdaq_spack/packages/trace/package.py
+++ b/spack_repo/artdaq_spack/packages/trace/package.py
@@ -84,7 +84,7 @@ class Trace(CMakePackage):
 
         # Source the functions
         file_to_source = self.prefix.join("bin/trace_functions.sh")
-        print(f'source {file_to_source}')
+        # print(f'source {file_to_source}')
 
         # Binaries.
         env.prepend_path("PATH", os.path.join(prefix, "bin"))


### PR DESCRIPTION
Some of the dune bits depend on "art-suite", so a no-bundle variant was needed there.  And newer boosts use signals2, not signals, and getting rid of a debug print.